### PR TITLE
Changes to BrightcoveVideo item and BuildMultipartFormDataPostRequest

### DIFF
--- a/source/BrightcoveOS .NET-MAPI-Wrapper/Api/BrightcoveApi.audio.write.cs
+++ b/source/BrightcoveOS .NET-MAPI-Wrapper/Api/BrightcoveApi.audio.write.cs
@@ -16,31 +16,16 @@ namespace BrightcoveMapiWrapper.Api
 		/// Creates a new audio track in Brightcove by uploading a file.
 		/// </summary>
 		/// <param name="audioTrack">The audio track to create</param>
-		/// <param name="fileName">The name of the file being uploaded.</param>
-		/// <param name="fileBytes">The contents of the file</param>
-		/// <returns>The numeric ID of the uploaded track</returns>
-		public long CreateAudioTrack(BrightcoveAudioTrack audioTrack, string fileName, byte[] fileBytes)
-		{
-			BrightcoveParamCollection parms = CreateWriteParamCollection("create_audiotrack",
-																		 methodParams => methodParams.Add("audiotrack", audioTrack));
-			return RunFilePost<BrightcoveResultContainer<long>>(parms, fileName, fileBytes).Result;
-		}
-
-		/// <summary>
-		/// Creates a new audio track in Brightcove by uploading a file.
-		/// </summary>
-		/// <param name="audioTrack">The audio track to create</param>
-		/// <param name="fileToUpload">The full path to the file to be uploaded.</param>
+        /// <param name="fileToUpload">The full path to the file to be uploaded.</param>
 		/// <returns>The numeric ID of the uploaded track</returns>
 		public long CreateAudioTrack(BrightcoveAudioTrack audioTrack, string fileToUpload)
 		{
-			string fileName;
-			byte[] fileBytes;
-			GetFileUploadInfo(fileToUpload, out fileName, out fileBytes);
-
-			return CreateAudioTrack(audioTrack, fileName, fileBytes);
+			BrightcoveParamCollection parms = CreateWriteParamCollection("create_audiotrack",
+																		 methodParams => methodParams.Add("audiotrack", audioTrack));
+			return RunFilePost<BrightcoveResultContainer<long>>(parms, fileToUpload).Result;
 		}
 
+	
 		#region AddAudioImage
 
 		/// <summary>
@@ -107,11 +92,7 @@ namespace BrightcoveMapiWrapper.Api
 		/// <returns>The image that was added or updated.</returns>
 		private BrightcoveImage DoAddAudioImage(BrightcoveImage image, string fileToUpload, long audioTrackId, string audioTrackReferenceId, bool resize)
 		{
-			string fileName;
-			byte[] fileBytes;
-			GetFileUploadInfo(fileToUpload, out fileName, out fileBytes);
-
-			string propName;
+		    string propName;
 			object propValue;
 			GetIdValuesForUpload(audioTrackId, audioTrackReferenceId, "audiotrack_id", "audiotrack_reference_id", out propName, out propValue);
 
@@ -123,7 +104,7 @@ namespace BrightcoveMapiWrapper.Api
 																			 methodParams.Add(propName, propValue);
 																		 });
 
-			return RunFilePost<BrightcoveResultContainer<BrightcoveImage>>(parms, fileName, fileBytes).Result;
+            return RunFilePost<BrightcoveResultContainer<BrightcoveImage>>(parms, fileToUpload).Result;
 		}
 
 		#endregion

--- a/source/BrightcoveOS .NET-MAPI-Wrapper/Api/BrightcoveApi.cs
+++ b/source/BrightcoveOS .NET-MAPI-Wrapper/Api/BrightcoveApi.cs
@@ -102,9 +102,9 @@ namespace BrightcoveMapiWrapper.Api
 		/// <param name="fileData"></param>
 		/// <param name="postParams"></param>
 		/// <returns></returns>
-		protected T RunFilePost<T>(BrightcoveParamCollection postParams, string fileName, byte[] fileData) where T : IJavaScriptConvertable
+		protected T RunFilePost<T>(BrightcoveParamCollection postParams, string fileName) where T : IJavaScriptConvertable
 		{
-			string json = Connector.GetFilePostResponseJson(SerializeJson(postParams), fileName, fileData);
+			string json = Connector.GetFilePostResponseJson(SerializeJson(postParams), fileName);
 			return DeserializeJson<T>(json);
 		}
 
@@ -165,16 +165,6 @@ namespace BrightcoveMapiWrapper.Api
 			}
 		}
 
-		private static void GetFileUploadInfo(string fileToUpload, out string fileName, out byte[] fileBytes)
-		{
-			FileInfo fileInfo = new FileInfo(fileToUpload);
-			if (!fileInfo.Exists)
-			{
-				throw new ArgumentException(String.Format("The specified file to upload does not exist: \"{0}\"", fileInfo.FullName));
-			}
-
-			fileName = fileInfo.Name;
-			fileBytes = File.ReadAllBytes(fileInfo.FullName);
-		}
+		
 	}
 }

--- a/source/BrightcoveOS .NET-MAPI-Wrapper/Api/BrightcoveApi.video.write.cs
+++ b/source/BrightcoveOS .NET-MAPI-Wrapper/Api/BrightcoveApi.video.write.cs
@@ -13,25 +13,24 @@ namespace BrightcoveMapiWrapper.Api
 	{
 		#region CreateVideo
 
-		/// <summary>
-		/// Creates a new video by uploading a file.
-		/// </summary>
-		/// <param name="video">The metadata for the video you want to create.</param>
-		/// <param name="fileName">The full path to the file to be uploaded.</param>
-		/// <param name="fileBytes">The contents of the file</param>
-		/// <param name="encodeTo">If the file requires transcoding, use this parameter to specify the target encoding. 
-		/// Valid values are MP4 or FLV, representing the H264 and VP6 codecs respectively. Note that transcoding of 
-		/// FLV files to another codec is not currently supported. This parameter is optional and defaults to FLV.</param>
-		/// <param name="createMultipleRenditions">If the file is a supported transcodeable type, this optional flag can be 
-		/// used to control the number of transcoded renditions. If true (default), multiple renditions at varying encoding 
-		/// rates and dimensions are created. Setting this to false will cause a single transcoded VP6 rendition to be created 
-		/// at the standard encoding rate and dimensions.</param>
-		/// <param name="preserveSourceRendition">If the video file is H.264 encoded and if createMultipleRenditions is true, 
-		/// then multiple VP6 renditions are created and in addition the H.264 source is retained as an additional rendition.</param>
-		/// <param name="h264NoProcessing">Use this option to prevent H.264 source files from being transcoded. This parameter cannot
-		/// be used in combination with create_multiple_renditions. It is optional and defaults to false.</param>
-		/// <returns>The numeric ID of the newly created video.</returns>
-		public long CreateVideo(BrightcoveVideo video, string fileName, byte[] fileBytes, EncodeTo encodeTo, bool createMultipleRenditions, bool preserveSourceRendition, bool h264NoProcessing)
+	    /// <summary>
+	    /// Creates a new video by uploading a file.
+	    /// </summary>
+	    /// <param name="video">The metadata for the video you want to create.</param>
+	    /// <param name="fileToUpload">The full path to the file to be uploaded.</param>
+	    /// <param name="encodeTo">If the file requires transcoding, use this parameter to specify the target encoding. 
+	    /// Valid values are MP4 or FLV, representing the H264 and VP6 codecs respectively. Note that transcoding of 
+	    /// FLV files to another codec is not currently supported. This parameter is optional and defaults to FLV.</param>
+	    /// <param name="createMultipleRenditions">If the file is a supported transcodeable type, this optional flag can be 
+	    /// used to control the number of transcoded renditions. If true (default), multiple renditions at varying encoding 
+	    /// rates and dimensions are created. Setting this to false will cause a single transcoded VP6 rendition to be created 
+	    /// at the standard encoding rate and dimensions.</param>
+	    /// <param name="preserveSourceRendition">If the video file is H.264 encoded and if createMultipleRenditions is true, 
+	    /// then multiple VP6 renditions are created and in addition the H.264 source is retained as an additional rendition.</param>
+	    /// <param name="h264NoProcessing">Use this option to prevent H.264 source files from being transcoded. This parameter cannot
+	    /// be used in combination with create_multiple_renditions. It is optional and defaults to false.</param>
+	    /// <returns>The numeric ID of the newly created video.</returns>
+	    public long CreateVideo(BrightcoveVideo video, string fileToUpload, EncodeTo encodeTo, bool createMultipleRenditions, bool preserveSourceRendition, bool h264NoProcessing)
 		{
 			BrightcoveParamCollection parms = CreateWriteParamCollection("create_video",
 																		 methodParams =>
@@ -45,36 +44,10 @@ namespace BrightcoveMapiWrapper.Api
 																			 methodParams.Add("preserve_source_rendition", preserveSourceRendition.ToString().ToLower());
 																			 methodParams.Add("H264NoProcessing ", h264NoProcessing.ToString().ToLower());
 																		 });
-			return RunFilePost<BrightcoveResultContainer<long>>(parms, fileName, fileBytes).Result;
+			return RunFilePost<BrightcoveResultContainer<long>>(parms, fileToUpload).Result;
 		}
 
-		/// <summary>
-		/// Creates a new video by uploading a file.
-		/// </summary>
-		/// <param name="video">The metadata for the video you want to create.</param>
-		/// <param name="fileToUpload">The full path to the file to be uploaded.</param>
-		/// <param name="encodeTo">If the file requires transcoding, use this parameter to specify the target encoding. 
-		/// Valid values are MP4 or FLV, representing the H264 and VP6 codecs respectively. Note that transcoding of 
-		/// FLV files to another codec is not currently supported. This parameter is optional and defaults to FLV.</param>
-		/// <param name="createMultipleRenditions">If the file is a supported transcodeable type, this optional flag can be 
-		/// used to control the number of transcoded renditions. If true (default), multiple renditions at varying encoding 
-		/// rates and dimensions are created. Setting this to false will cause a single transcoded VP6 rendition to be created 
-		/// at the standard encoding rate and dimensions.</param>
-		/// <param name="preserveSourceRendition">If the video file is H.264 encoded and if createMultipleRenditions is true, 
-		/// then multiple VP6 renditions are created and in addition the H.264 source is retained as an additional rendition.</param>
-		/// <param name="h264NoProcessing">Use this option to prevent H.264 source files from being transcoded. This parameter cannot
-		/// be used in combination with create_multiple_renditions. It is optional and defaults to false.</param>
-		/// <returns>The numeric ID of the newly created video.</returns>
-		public long CreateVideo(BrightcoveVideo video, string fileToUpload, EncodeTo encodeTo, bool createMultipleRenditions, bool preserveSourceRendition, bool h264NoProcessing)
-		{
-			string fileName;
-			byte[] fileBytes;
-			GetFileUploadInfo(fileToUpload, out fileName, out fileBytes);
-
-			return CreateVideo(video, fileName, fileBytes, encodeTo, createMultipleRenditions, preserveSourceRendition,
-			                   h264NoProcessing);
-		}
-
+		
 		/// <summary>
 		/// Creates a new video by uploading a file.
 		/// </summary>
@@ -327,11 +300,7 @@ namespace BrightcoveMapiWrapper.Api
 
 		private BrightcoveImage DoAddImage(BrightcoveImage image, string fileToUpload, long videoId, string videoReferenceId, bool resize)
 		{
-			string fileName;
-			byte[] fileBytes;
-			GetFileUploadInfo(fileToUpload, out fileName, out fileBytes);
-
-			string propName;
+		    string propName;
 			object propValue;
 			GetIdValuesForUpload(videoId, videoReferenceId, "video_id", "video_reference_id", out propName, out propValue);
 
@@ -343,7 +312,7 @@ namespace BrightcoveMapiWrapper.Api
 																			 methodParams.Add(propName, propValue);
 																		 });
 
-			return RunFilePost<BrightcoveResultContainer<BrightcoveImage>>(parms, fileName, fileBytes).Result;
+            return RunFilePost<BrightcoveResultContainer<BrightcoveImage>>(parms, fileToUpload).Result;
 		}
 
 		#endregion
@@ -376,11 +345,7 @@ namespace BrightcoveMapiWrapper.Api
 
 		private BrightcoveLogoOverlay DoAddLogoOverlay(BrightcoveLogoOverlay logoOverlay, string fileToUpload, long videoId, string videoReferenceId)
 		{
-			string fileName;
-			byte[] fileBytes;
-			GetFileUploadInfo(fileToUpload, out fileName, out fileBytes);
-
-			string propName;
+		    string propName;
 			object propValue;
 			GetIdValuesForUpload(videoId, videoReferenceId, "video_id", "video_reference_id", out propName, out propValue);
 
@@ -391,7 +356,7 @@ namespace BrightcoveMapiWrapper.Api
 																			 methodParams.Add(propName, propValue);
 																		 });
 
-			return RunFilePost<BrightcoveResultContainer<BrightcoveLogoOverlay>>(parms, fileName, fileBytes).Result;
+			return RunFilePost<BrightcoveResultContainer<BrightcoveLogoOverlay>>(parms, fileToUpload).Result;
 		}
 
 		#endregion

--- a/source/BrightcoveOS .NET-MAPI-Wrapper/Api/Connectors/BrightcoveApiConnector.cs
+++ b/source/BrightcoveOS .NET-MAPI-Wrapper/Api/Connectors/BrightcoveApiConnector.cs
@@ -70,21 +70,20 @@ namespace BrightcoveMapiWrapper.Api.Connectors
 		/// Performs an API Write (HTTP POST) request that includes file data
 		/// </summary>
 		/// <param name="postJson"></param>
-		/// <param name="fileName"></param>
-		/// <param name="fileData"></param>
+		/// <param name="fileToUpload"></param>
 		/// <returns></returns>
-		public virtual string GetFilePostResponseJson(string postJson, string fileName, byte[] fileData)
+		public virtual string GetFilePostResponseJson(string postJson, string fileToUpload)
 		{
-			return GetPostResponseJson(postJson, new FileParameter(fileData, fileName));
+			return GetPostResponseJson(postJson, fileToUpload);
 		}
 
-		/// <summary>
-		/// Performs an API Write (HTTP POST) request, with an optional callback to add extra request params
-		/// </summary>
-		/// <param name="postJson"></param>
-		/// <param name="fileParameter"></param>
-		/// <returns></returns>
-		protected virtual string GetPostResponseJson(string postJson, FileParameter fileParameter)
+	    /// <summary>
+	    /// Performs an API Write (HTTP POST) request, with an optional callback to add extra request params
+	    /// </summary>
+	    /// <param name="postJson"></param>
+	    /// <param name="fileToPost"></param>
+	    /// <returns></returns>
+	    protected virtual string GetPostResponseJson(string postJson, string fileToPost)
 		{
 			// Build the URL
 			string url = Configuration.ApiWriteUrl;
@@ -96,9 +95,9 @@ namespace BrightcoveMapiWrapper.Api.Connectors
 			postParameters.Add("json", postJson);
 
 			HttpWebRequest request;
-			if (fileParameter != null)
+            if (!string.IsNullOrEmpty(fileToPost))
 			{
-				request = RequestBuilder.BuildMultipartFormDataPostRequest(url, postParameters, fileParameter);
+				request = RequestBuilder.BuildMultipartFormDataPostRequest(url,fileToPost, postParameters);
 			}
 			else
 			{

--- a/source/BrightcoveOS .NET-MAPI-Wrapper/Api/Connectors/IBrightcoveApiConnector.cs
+++ b/source/BrightcoveOS .NET-MAPI-Wrapper/Api/Connectors/IBrightcoveApiConnector.cs
@@ -8,6 +8,6 @@ namespace BrightcoveMapiWrapper.Api.Connectors
 		BrightcoveApiConfig Configuration { get; set; }
 		string GetResponseJson(NameValueCollection requestParams);
 		string GetPostResponseJson(string postJson);
-		string GetFilePostResponseJson(string postJson, string fileName, byte[] fileData);
+		string GetFilePostResponseJson(string postJson, string fileToUpload);
 	}
 }

--- a/source/BrightcoveOS .NET-MAPI-Wrapper/Api/Connectors/IRequestBuilder.cs
+++ b/source/BrightcoveOS .NET-MAPI-Wrapper/Api/Connectors/IRequestBuilder.cs
@@ -31,6 +31,6 @@ namespace BrightcoveMapiWrapper.Api.Connectors
 		/// <param name="postParameters">The parameters to POST</param>
 		/// <param name="fileParameter">The file data to POST</param>
 		/// <returns></returns>
-		HttpWebRequest BuildMultipartFormDataPostRequest(string postUrl, NameValueCollection postParameters, FileParameter fileParameter);
+		HttpWebRequest BuildMultipartFormDataPostRequest(string postUrl, string fileToPost, NameValueCollection postParameters);
 	}
 }

--- a/source/BrightcoveOS .NET-MAPI-Wrapper/Model/Items/BrightcoveVideo.cs
+++ b/source/BrightcoveOS .NET-MAPI-Wrapper/Model/Items/BrightcoveVideo.cs
@@ -11,6 +11,7 @@ namespace BrightcoveMapiWrapper.Model.Items
 {
 	/// <summary>
 	/// The BrightcoveVideo object is an aggregate of metadata and asset information associated with a video.
+    /// reference: http://support.brightcove.com/en/docs/media-api-objects-reference#Video
 	/// </summary>
 	public class BrightcoveVideo : BrightcoveItem, IJavaScriptConvertable
 	{
@@ -24,6 +25,17 @@ namespace BrightcoveMapiWrapper.Model.Items
 			get;
 			private set;
 		}
+
+        /// <summary>
+        /// A string representing the ad key/value pairs assigned to the video. Key/value pairs are formatted 
+        /// as key=value and are separated by ampersands (&). For example:
+        /// "adKeys":"category=sports&live=true" 
+        /// </summary>
+        public string AdKeys
+        {
+            get;
+            set;
+        }
 
 		/// <summary>
 		/// The date this Video was created.
@@ -40,7 +52,7 @@ namespace BrightcoveMapiWrapper.Model.Items
 		public ICollection<BrightcoveCuePoint> CuePoints
 		{
 			get;
-			private set;
+			set;
 		}
 
 		/// <summary>
@@ -49,10 +61,12 @@ namespace BrightcoveMapiWrapper.Model.Items
 		public CustomFieldCollection CustomFields
 		{
 			get;
-			private set;
+			set;
 		}
 
-		/// <summary>
+     
+        
+        /// <summary>
 		/// Either FREE or AD_SUPPORTED. AD_SUPPORTED means that ad requests are enabled for the Video.
 		/// </summary>
 		public Economics Economics
@@ -80,6 +94,41 @@ namespace BrightcoveMapiWrapper.Model.Items
 			get;
 			private set;
 		}
+
+        /// <summary>
+        /// True indicates that the video is geo-restricted.
+        /// http://support.brightcove.com/en/docs/geo-filtering-media-api
+        /// </summary>
+        public bool GeoRestricted
+        {
+            get; set;
+        }
+
+        /// <summary>
+        /// A list of the ISO-3166
+        /// two-letter codes of the countries to enforce geo-restriction rules on. Use lowercase for the country code
+        /// more info => http://support.brightcove.com/en/docs/geo-filtering-media-api
+        /// <code>
+        /// .net example:
+        ///  CultureInfo[] cultures = CultureInfo.GetCultures(CultureTypes.SpecificCultures);
+        ///  foreach (CultureInfo culture in cultures)
+        ///  {
+        ///     RegionInfo region = new RegionInfo(culture.LCID);
+        ///     if (region.ThreeLetterISORegionName.ToUpper() == name)
+        ///         {
+        ///             return region.TwoLetterISORegionName;
+        ///         }
+        ///  }*/
+        /// </code>
+        /// </summary>
+        public List<string> GeoFilteredCountries { get; set; }
+
+        /// <summary>
+        /// If true, the video can be viewed in all countries except those listed in geoFilteredCountries;
+        /// if false, the video can be viewed only in the countries listed in geoFilteredCountries.
+        /// http://support.brightcove.com/en/docs/geo-filtering-media-api
+        /// </summary>
+        public bool GeoFilterExclude { get; set; }
 
 		/// <summary>
 		/// A number that uniquely identifies this Video, assigned by Brightcove when the Video is created.
@@ -204,7 +253,7 @@ namespace BrightcoveMapiWrapper.Model.Items
 		public ICollection<BrightcoveRendition> Renditions
 		{
 			get;
-			private set;
+			set;
 		}
 
 		/// <summary>
@@ -233,7 +282,7 @@ namespace BrightcoveMapiWrapper.Model.Items
 		public ICollection<string> Tags
 		{
 			get;
-			private set;
+			set;
 		}
 
 		/// <summary>
@@ -269,10 +318,19 @@ namespace BrightcoveMapiWrapper.Model.Items
 
 		#endregion
 
+        /// <summary>
+        /// Creates an object representing a single video within Brightcove's system.
+        /// </summary>
+        [Obsolete("ShortDescription is a required property")]
+        public BrightcoveVideo():this(".")
+        {
+        }
+
+
 		/// <summary>
 		/// Creates an object representing a single video within Brightcove's system.
 		/// </summary>
-		public BrightcoveVideo()
+		public BrightcoveVideo(string shortDescription)
 		{
 			Tags = new List<string>();
 			CustomFields = new CustomFieldCollection();
@@ -280,6 +338,10 @@ namespace BrightcoveMapiWrapper.Model.Items
 			CuePoints = new List<BrightcoveCuePoint>();
 			ItemState = ItemState.Active;
 			Economics = Economics.Free;
+            if(string.IsNullOrEmpty(shortDescription)  || shortDescription.Trim()==string.Empty)
+                throw new ArgumentNullException(shortDescription);
+            //required field
+            ShortDescription = shortDescription;
 		}
 
 		#region IJavaScriptConvertable implementation


### PR DESCRIPTION
BrightCoveVideo updated to correctly reflect API doc http://support.brightcove.com/en/docs/media-api-objects-reference#Video
1) Tags property editable
2) Added adKeys, geoRestricted, geoFilteredCountries, geoFilterExclude
3) Created a new constructor for ShortDescription

BrightCove API Connector code refactored so that large files are supported.
New multipart upload code from stackoverflow.
