### PR TITLE
BrightcoveApiException message is null if using default constructors

### DIFF
--- a/source/BrightcoveOS .NET-MAPI-Wrapper/Api/BrightcoveApiException.cs
+++ b/source/BrightcoveOS .NET-MAPI-Wrapper/Api/BrightcoveApiException.cs
@@ -15,7 +15,7 @@ namespace BrightcoveMapiWrapper.Api
 		{
 			get
 			{
-				return _message;
+                return string.IsNullOrEmpty(_message) ? base.Message : _message;
 			}
 		}
 


### PR DESCRIPTION
If you use a default constructor when throwing an exception, the message returned from the Message property will be null instead of the message passed. I just added a check to see if the message is empty/null and if it is, return the base exception message.
