### PR TITLE
CreateVideo method with no file upload

### DIFF
--- a/source/BrightcoveOS .NET-MAPI-Wrapper/Api/BrightcoveApi.video.write.cs
+++ b/source/BrightcoveOS .NET-MAPI-Wrapper/Api/BrightcoveApi.video.write.cs
@@ -92,9 +92,9 @@ namespace BrightcoveMapiWrapper.Api
         /// Valid values are MP4 or FLV, representing the H264 and VP6 codecs respectively. Note that transcoding of 
         /// FLV files to another codec is not currently supported. This parameter is optional and defaults to FLV.</param>
         /// <returns>The numeric ID of the newly created video.</returns>
-        public long CreateVideo(BrightcoveVideo video, EncodeTo encodeTo)
+        public long CreateVideo(BrightcoveVideo video)
         {
-            return CreateVideo(video, (FileUploadInfo)null, encodeTo, true, false, false);
+            return CreateVideo(video, (FileUploadInfo)null, EncodeTo.None, false, false, false);
         }
 
 		/// <summary>

--- a/tests/BrightcoveOS .NET-MAPI-Wrapper.Tests/IntegrationTests/VideoWrite/CreateVideoTests.cs
+++ b/tests/BrightcoveOS .NET-MAPI-Wrapper.Tests/IntegrationTests/VideoWrite/CreateVideoTests.cs
@@ -29,18 +29,20 @@ namespace BrightcoveOS.NET_MAPI_Wrapper.Tests.IntegrationTests.VideoWrite
 		}
 
         [Test]
-        public void CreateVideo_RemoteUrl()
+        public void CreateVideo_VideoFullLength()
         {
             BrightcoveVideo video = new BrightcoveVideo();
             video.Name = "Test Video Creation";
             video.ReferenceId = "test-reference-id";
             video.ShortDescription = "Test video, created via the API. Video is from the Creative Commons: http://creativecommons.org/videos/building-on-the-past";
-            video.Renditions.Add(new BrightcoveRendition
+            video.VideoFullLength = new BrightcoveRendition
                 {
-                    RemoteUrl = "http://blip.tv/file/get/Commonscreative-BuildingOnThePast896.mov"
-                });
+                    RemoteUrl = "http://blip.tv/file/get/Commonscreative-BuildingOnThePast896.mov",
+                    ControllerType = ControllerType.Default,
+                    VideoCodec = VideoCodec.H264
+                };
 
-            long newId = _api.CreateVideo(video, EncodeTo.Mp4);
+            long newId = _api.CreateVideo(video);
             Assert.That(newId, Is.GreaterThan(0));
         }
 	}


### PR DESCRIPTION
The BC Media API lets you use the create_video method without uploading a file using the videoFullLength rendition parameter and setting a remote URL.  However, the API only had CreateVideo methods expecting file paths or upload info.

I wrote a simple method that allows you to skip the file upload for the remote URL scenario described here: http://support.brightcove.com/en/video-cloud/docs/creating-videos-remote-assets-using-media-api
