### PR TITLE
Added new Enum values for ControllerType.  Created associated unit tests.

### DIFF
--- a/source/BrightcoveOS .NET-MAPI-Wrapper/Model/BrightcoveEnumerations.cs
+++ b/source/BrightcoveOS .NET-MAPI-Wrapper/Model/BrightcoveEnumerations.cs
@@ -209,7 +209,32 @@ namespace BrightcoveMapiWrapper.Model
 		/// <summary>
 		/// Uses the default controller.
 		/// </summary>
-		Default
+		Default,
+        /// <summary>
+        /// Uses the Akamai HD controller.
+        /// </summary>
+        AkamaiHd,
+        /// <summary>
+        /// Uses the Akamai HD Live controller.
+        /// </summary>
+        AkamaiHdLive,
+        /// <summary>
+        /// Uses the Akamai Streaming controller.
+        /// </summary>
+        AkamaiHd2,
+        /// <summary>
+        /// Uses the Akamai Secure Streaming controller.
+        /// </summary>
+        AkamaiSecureStreaming,
+        /// <summary>
+        /// Uses the Akamai Streaming controller.
+        /// </summary>
+        AkamaiStreaming,
+        /// <summary>
+        /// Uses the Limelight Media vault(?) controller.
+        /// </summary>
+        LimelightMediavalut
+
 	}
 
 	/// <summary>

--- a/tests/BrightcoveOS .NET-MAPI-Wrapper.Tests/BrightcoveOS .NET-MAPI-Wrapper.Tests.csproj
+++ b/tests/BrightcoveOS .NET-MAPI-Wrapper.Tests/BrightcoveOS .NET-MAPI-Wrapper.Tests.csproj
@@ -44,6 +44,7 @@
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
     <Reference Include="System.Web" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Xml.Linq">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
@@ -116,6 +117,7 @@
     <Compile Include="IntegrationTests\VideoWrite\RemoveLogoOverlayTests.cs" />
     <Compile Include="IntegrationTests\VideoWrite\ShareVideoTests.cs" />
     <Compile Include="IntegrationTests\VideoWrite\UnshareVideoTests.cs" />
+    <Compile Include="IntegrationTests\VideoWrite\VideoWriteCoreTests.cs" />
     <Compile Include="IntegrationTests\VideoWrite\UpdateVideoTests.cs" />
     <Compile Include="IntegrationTests\VideoWrite\VideoWriteTestBase.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/tests/BrightcoveOS .NET-MAPI-Wrapper.Tests/IntegrationTests/VideoWrite/VideoWriteCoreTests.cs
+++ b/tests/BrightcoveOS .NET-MAPI-Wrapper.Tests/IntegrationTests/VideoWrite/VideoWriteCoreTests.cs
@@ -1,0 +1,59 @@
+﻿using System.Collections.Generic;
+using System.Web.UI;
+using BrightcoveMapiWrapper.Model;
+using BrightcoveMapiWrapper.Model.Containers;
+using BrightcoveMapiWrapper.Model.Items;
+using BrightcoveMapiWrapper.Serialization;
+using System.Web.Script.Serialization;
+using BrightcoveMapiWrapper.Util.Extensions;
+using NUnit.Framework;
+
+namespace BrightcoveOS.NET_MAPI_Wrapper.Tests.IntegrationTests.VideoWrite
+{
+    [TestFixture]
+    public class VideoWriteCoreTests : VideoWriteTestBase
+    {
+        [Test]
+        public void Deserialize_Video_Test_Basic()
+        {
+            JavaScriptSerializer serializer = BrightcoveSerializerFactory.GetSerializer();
+            IDictionary<string, object> dictionary = new Dictionary<string, object>();
+            var testrenditionCollection = new BrightcoveItemCollection<BrightcoveRendition>();
+            var testrendition = new BrightcoveRendition();
+            testrendition.ControllerType = ControllerType.AkamaiHd;
+            testrenditionCollection.Add(testrendition);
+            dictionary.Add("renditions", testrenditionCollection);
+
+            var renditions =
+                serializer.ConvertToType<BrightcoveItemCollection<BrightcoveRendition>>(dictionary["renditions"]);
+            Assert.That(renditions[0].ControllerType, Is.EqualTo(ControllerType.AkamaiHd));
+        }
+
+        [Test]
+        public void EnumExtension_ToBrightcoveName_Test()
+        {
+           var testrendition = new BrightcoveRendition();
+           testrendition.ControllerType = ControllerType.AkamaiHd;
+           var brightcoveName = testrendition.ControllerType.ToBrightcoveName();
+           Assert.That(brightcoveName, Is.EqualTo("AKAMAI_HD"));
+        }
+
+        [Test]
+        public void EnumExtension_ToBrightcoveEnum_Test()
+        {
+            const string brightcoveName = "AKAMAI_HD2";
+            var testrendition = new BrightcoveRendition();
+            testrendition.ControllerType = (brightcoveName).ToBrightcoveEnum<ControllerType>();
+            Assert.That(testrendition.ControllerType, Is.EqualTo(ControllerType.AkamaiHd2));
+        }
+
+        [Test]
+        public void EnumExtension_ToBrightcoveEnum_Test_InvalidValue()
+        {
+            const string brightcoveName = "BAD-CONTROLLERTYPE-NAME";
+            var testrendition = new BrightcoveRendition();
+            testrendition.ControllerType = (brightcoveName).ToBrightcoveEnum<ControllerType>();
+            Assert.That(testrendition.ControllerType, Is.EqualTo(ControllerType.None));
+        }
+    }
+}


### PR DESCRIPTION
I added these new Enums to correspond to the ControllerType values we are seeing in the brightcove video data.  This will eliminate the exceptions we are seeing regarding the controller type being "None."
